### PR TITLE
Fix executor termination timeout setter

### DIFF
--- a/src/main/java/eu/mihosoft/asyncutils/Executor.java
+++ b/src/main/java/eu/mihosoft/asyncutils/Executor.java
@@ -510,7 +510,7 @@ public final class Executor {
      * @return this executor
      */
     public Executor setTerminationTimeout(long timeout) {
-        this.terminationTimeout = terminationTimeout;
+        this.terminationTimeout = timeout;
         return this;
     }
 

--- a/src/test/java/eu/mihosoft/asyncutils/ExecutorTerminationTimeoutTest.java
+++ b/src/test/java/eu/mihosoft/asyncutils/ExecutorTerminationTimeoutTest.java
@@ -1,0 +1,15 @@
+package eu.mihosoft.asyncutils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExecutorTerminationTimeoutTest {
+    @Test
+    public void setAndGetTerminationTimeout() {
+        Executor executor = Executor.newInstance(1);
+        long timeout = 12345L;
+        executor.setTerminationTimeout(timeout);
+        assertEquals(timeout, executor.getTerminationTimeout());
+    }
+}


### PR DESCRIPTION
## Summary
- fix termination timeout setter which ignored the provided timeout
- add regression test for termination timeout

## Testing
- `./gradlew test --tests ExecutorTerminationTimeoutTest`

------
https://chatgpt.com/codex/tasks/task_e_684583e35190832a8c0d67f203a44002