### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Of course, we could use Streams, Fork-Join APIs and Futures. But either the APIs
 or they lack features such as control over how exceptions are handled or how to specify how many threads should be 
 used to process the tasks.
 
-Task objects provide sophisiticated telemetry information:
+Task objects provide sophisticated telemetry information:
 
 ```java
 var t = executor.submit(()->{...});


### PR DESCRIPTION
## Summary
- fix a spelling mistake in README (`sophisiticated` to `sophisticated`)

## Testing
- `./gradlew test` *(fails: took too long / aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684584b0b844832ab13aa8038829d789