### PR TITLE
Fix ExecutorEvent Javadoc

### DIFF
--- a/src/main/java/eu/mihosoft/asyncutils/Executor.java
+++ b/src/main/java/eu/mihosoft/asyncutils/Executor.java
@@ -119,7 +119,9 @@ public final class Executor {
     }
 
     /**
-     * Executor event that indicates whether the executor isstarted, cancelled, shotdown or terminated.
+     * Executor event that indicates whether the executor is started, cancelled,
+     * shutdown or terminated.
+     *
      * @param executor the executor
      * @param oldState the old state
      * @param newState the new state


### PR DESCRIPTION
## Summary
- fix ExecutorEvent javadoc comment

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Deprecated Gradle features used)*

------
https://chatgpt.com/codex/tasks/task_e_684584e74854832a9938ca92ced52aae