### PR TITLE
Fix termination timeout setter

### DIFF
--- a/src/main/java/eu/mihosoft/asyncutils/Executor.java
+++ b/src/main/java/eu/mihosoft/asyncutils/Executor.java
@@ -510,7 +510,7 @@ public final class Executor {
      * @return this executor
      */
     public Executor setTerminationTimeout(long timeout) {
-        this.terminationTimeout = terminationTimeout;
+        this.terminationTimeout = timeout;
         return this;
     }
 


### PR DESCRIPTION
## Summary
- fix the setter in `Executor.setTerminationTimeout()`
- verify tests compile

## Testing
- `./gradlew testClasses --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684584cb12cc832aac61df35dae8b809